### PR TITLE
🏷 Relax typing on `Client.remove_connection`

### DIFF
--- a/ansq/tcp/reader.py
+++ b/ansq/tcp/reader.py
@@ -22,7 +22,7 @@ from ansq.utils import get_logger
 
 if TYPE_CHECKING:
     from ansq.tcp.connection import NSQConnection
-    from ansq.tcp.types import NSQMessage
+    from ansq.tcp.types import NSQMessage, TCPConnection
 
 
 class Reader(Client):
@@ -302,7 +302,7 @@ class Lookupd:
 
         return addresses
 
-    def _on_close_connection(self, connection: "NSQConnection") -> None:
+    def _on_close_connection(self, connection: "TCPConnection") -> None:
         """A callback to be called after a connection being closed."""
         # Remove the connection from the reader so that lookupd could add it later
         self._reader.remove_connection(connection)

--- a/ansq/tcp/types/client.py
+++ b/ansq/tcp/types/client.py
@@ -6,6 +6,7 @@ from .connection import ConnectionOptions
 
 if TYPE_CHECKING:
     from ansq.tcp.connection import NSQConnection
+    from ansq.tcp.types import TCPConnection
 
 
 class Client:
@@ -62,7 +63,7 @@ class Client:
         """Add connection to connections pool."""
         self._connections[connection.id] = connection
 
-    def remove_connection(self, connection: "NSQConnection") -> None:
+    def remove_connection(self, connection: "TCPConnection") -> None:
         """Remove connection from connections pool."""
         if connection.id in self._connections:
             del self._connections[connection.id]


### PR DESCRIPTION
Such typing relaxing is necessary for `Client.remove_connection` to be acceptable as `ConnectionOptions.on_close` attribute. `ConnectionOptions.on_close` type doesn't garantee that `Client.remove_connection` will get `NSQConnection` as an argument. This could lead to `Client.remove_connection` trying to access `NSQConnection` attributes and/or methods that `TCPConnection` instance doesn't provide. Thus, `mypy` was reporting an error correctly.